### PR TITLE
Bugfix/gather all historical players

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.csv
+*.pyc
+
+.idea/

--- a/Base_File_NFL_Stats.py
+++ b/Base_File_NFL_Stats.py
@@ -14,37 +14,37 @@ def Get_Players_and_Ids_From_CSV_File(filename):
 
 # Only one should be executed based on if you want to get the player names and
 # ids from a csv file or from the website.
-Players = Get_and_Store_All_Players_Names_and_Ids('Player_Ids_Urls.csv')
+Players = get_and_store_all_players_names_and_ids('Player_Ids_Urls.csv')
 #Players = Get_Players_and_Ids_From_CSV_File('Player_Ids_Urls.csv')
 
 
-# Get Basic Statistics
-count = 1
-for player_id in Players:
-    player = Player_Basic_Stats(Players[player_id])
-    player.Get_and_Store_Basic_Stats('Basic_Stats.csv')
-    if count % 100 == 0:
-        print('Processed basic stats for %d out of %d players' % (count,len(Players)))
-    count+=1
-    
-# Get Career Stats
-count = 1
-for player_id in Players:
-    player = Career_Stats(Players[player_id])
-    if Check_for_Stats_Webpage(player,'Career Stats'):
-        player.Get_and_Store_Career_Stats()
-    if count % 100 == 0:
-        print('Processed career stats for %d out of %d players' % (count,len(Players)))
-    count+=1
-
-# Get Game Logs
-count = 1
-for player_id in Players:
-    player = Game_Logs(Players[player_id])
-    if Check_for_Stats_Webpage(player,'Game Logs'):
-        player.Get_and_Store_Game_Logs()
-    if count % 100 == 0:
-        print('Processed game logs for %d out of %d players' % (count,len(Players)))
-    count+=1
+# # Get Basic Statistics
+# count = 1
+# for player_id in Players:
+#     player = Player_Basic_Stats(Players[player_id])
+#     player.Get_and_Store_Basic_Stats('Basic_Stats.csv')
+#     if count % 100 == 0:
+#         print('Processed basic stats for %d out of %d players' % (count,len(Players)))
+#     count+=1
+#
+# # Get Career Stats
+# count = 1
+# for player_id in Players:
+#     player = Career_Stats(Players[player_id])
+#     if Check_for_Stats_Webpage(player,'Career Stats'):
+#         player.Get_and_Store_Career_Stats()
+#     if count % 100 == 0:
+#         print('Processed career stats for %d out of %d players' % (count,len(Players)))
+#     count+=1
+#
+# # Get Game Logs
+# count = 1
+# for player_id in Players:
+#     player = Game_Logs(Players[player_id])
+#     if Check_for_Stats_Webpage(player,'Game Logs'):
+#         player.Get_and_Store_Game_Logs()
+#     if count % 100 == 0:
+#         print('Processed game logs for %d out of %d players' % (count,len(Players)))
+#     count+=1
 
 

--- a/Base_File_NFL_Stats.py
+++ b/Base_File_NFL_Stats.py
@@ -18,33 +18,33 @@ Players = get_and_store_all_players_names_and_ids('Player_Ids_Urls.csv')
 #Players = Get_Players_and_Ids_From_CSV_File('Player_Ids_Urls.csv')
 
 
-# # Get Basic Statistics
-# count = 1
-# for player_id in Players:
-#     player = Player_Basic_Stats(Players[player_id])
-#     player.Get_and_Store_Basic_Stats('Basic_Stats.csv')
-#     if count % 100 == 0:
-#         print('Processed basic stats for %d out of %d players' % (count,len(Players)))
-#     count+=1
-#
-# # Get Career Stats
-# count = 1
-# for player_id in Players:
-#     player = Career_Stats(Players[player_id])
-#     if Check_for_Stats_Webpage(player,'Career Stats'):
-#         player.Get_and_Store_Career_Stats()
-#     if count % 100 == 0:
-#         print('Processed career stats for %d out of %d players' % (count,len(Players)))
-#     count+=1
-#
-# # Get Game Logs
-# count = 1
-# for player_id in Players:
-#     player = Game_Logs(Players[player_id])
-#     if Check_for_Stats_Webpage(player,'Game Logs'):
-#         player.Get_and_Store_Game_Logs()
-#     if count % 100 == 0:
-#         print('Processed game logs for %d out of %d players' % (count,len(Players)))
-#     count+=1
+# Get Basic Statistics
+count = 1
+for player_id in Players:
+    player = Player_Basic_Stats(Players[player_id])
+    player.Get_and_Store_Basic_Stats('Basic_Stats.csv')
+    if count % 100 == 0:
+        print('Processed basic stats for %d out of %d players' % (count,len(Players)))
+    count+=1
+
+# Get Career Stats
+count = 1
+for player_id in Players:
+    player = Career_Stats(Players[player_id])
+    if Check_for_Stats_Webpage(player,'Career Stats'):
+        player.Get_and_Store_Career_Stats()
+    if count % 100 == 0:
+        print('Processed career stats for %d out of %d players' % (count,len(Players)))
+    count+=1
+
+# Get Game Logs
+count = 1
+for player_id in Players:
+    player = Game_Logs(Players[player_id])
+    if Check_for_Stats_Webpage(player,'Game Logs'):
+        player.Get_and_Store_Game_Logs()
+    if count % 100 == 0:
+        print('Processed game logs for %d out of %d players' % (count,len(Players)))
+    count+=1
 
 

--- a/Website_to_CSV_Functions/Obtain_Players_from_Website.py
+++ b/Website_to_CSV_Functions/Obtain_Players_from_Website.py
@@ -1,93 +1,111 @@
-import bs4, re, os.path, string
 from Player_Class import *
 from Website_to_CSV_Functions.Functions_Needed_For_All_Stats import *
 
-def Obtain_Number_of_Pages(soup,initial_url):
-    Pages = [1]
+import string
+import os
+
+
+def obtain_number_of_pages(soup):
+    pages = [1]
     for page in soup.find_all(title=re.compile('Go to page')):
         try:
-            Pages.append(int(page.contents[0]))
-        except:
+            pages.append(int(page.contents[0]))
+        except Exception as e:
             pass
-    return max(Pages)
+    return max(pages)
 
-def Get_Player_Name_and_Id(player,td,Players):
+
+def get_player_name_and_id(player, td):
     for a in td.find_all('a'):
         player.name = a.text
         
-        Attributes = a.attrs
-        pid = Attributes['href']
+        attributes = a.attrs
+        pid = attributes['href']
         pid = pid.split('/')
-        player.player_id = '/'.join([pid[2],pid[3]])
-        
-def Get_Players_Current_Status(player,td,Is_Current):
-    Status_Abbrev = {'ACT':'Active','RES':'Injured reserve',
-                     'NON':'Non football related injured reserve',
-                     'SUS':'Suspended','PUP':'Physically unable to perform',
-                     'UDF':'Unsigned draft pick','UFA':'Unsigned free agent',
-                     'EXE':'Exempt'}
-    if Is_Current:
-        player.current_status = Status_Abbrev[td.text]
+        player.player_id = '/'.join([pid[2], pid[3]])
+
+
+def get_players_current_status(player, td, is_current):
+    status_abbrev = {'ACT': 'Active',
+                     'RES': 'Injured reserve',
+                     'NON': 'Non football related injured reserve',
+                     'SUS': 'Suspended',
+                     'PUP': 'Physically unable to perform',
+                     'UDF': 'Unsigned draft pick',
+                     'UFA': 'Unsigned free agent',
+                     'EXE': 'Exempt'}
+
+    if is_current:
+        player.current_status = status_abbrev[td.text]
     else:
         player.current_status = 'Retired'
 
-def Get_Years_Played(player,td,Is_Current):
-    if not Is_Current:
+
+def get_years_played(player, td, is_current):
+    if not is_current:
         player.years_played = td.text
 
-def Get_Player_Information(Players,td_tags,col_num,name_index,status_index,
-                           years_played_index,Is_Current,filename):
+
+def get_player_information(players, td_tags, col_num, name_index, status_index,
+                           years_played_index, is_current, filename):
     count = 0
-    player=Player()
+    player = Player()
     for td in td_tags:
         index = count % col_num
         if index == name_index:
-            Get_Player_Name_and_Id(player,td,Players)
+            get_player_name_and_id(player, td)
         elif index == status_index:
-            Get_Players_Current_Status(player,td,Is_Current)
+            get_players_current_status(player, td, is_current)
         elif index == years_played_index:
-            Get_Years_Played(player,td,Is_Current)
+            get_years_played(player, td, is_current)
         elif index == col_num-1:
-            Players[player.player_id] = player
+            players[player.player_id] = player
             if not os.path.exists(filename):        
-                headers = ['Player Id','Name','Current Status','Years Played']
-                player.New_CSV_File(filename,headers)
-            Stats = [player.player_id,player.name,player.current_status,player.years_played]
-            player.Write_Stats_to_CSV(filename,Stats)
-            player=Player()
-        count+=1   
-   
-def Obtain_Players_And_Status(initial_url,url_parameters,Max_Page,Players,soup,filename):
-    for page_number in range(1,Max_Page+1):
+                headers = ['Player Id', 'Name', 'Current Status', 'Years Played']
+                player.New_CSV_File(filename, headers)
+            stats = [player.player_id, player.name, player.current_status, player.years_played]
+            player.Write_Stats_to_CSV(filename, stats)
+            player = Player()
+        count += 1
+
+
+def obtain_players_and_status(initial_url, url_parameters, players, soup, filename):
+    page_number = 1
+    max_page_estimate = obtain_number_of_pages(soup)
+
+    while page_number <= max_page_estimate:
         # NFL website parameter name for page number
         url_parameters['d-447263-p'] = page_number
-        soup = Get_HTML_Document(initial_url,url_parameters)
-        
-        for table in soup.find_all('table', id = 'result'):
+        soup = Get_HTML_Document(initial_url, url_parameters)
+
+        # Update estimate of maximum number of pages, based on what number we can currently see
+        max_page_estimate = obtain_number_of_pages(soup)
+
+        for table in soup.find_all('table', id='result'):
             td_tags = table.find_all('td')
             if url_parameters['playerType'] == 'current':
-                Get_Player_Information(Players,td_tags,13,2,3,4,True,filename)
+                get_player_information(players, td_tags, 13, 2, 3, 4, True, filename)
             else:
-                Get_Player_Information(Players,td_tags,12,0,1,2,False,filename)
+                get_player_information(players, td_tags, 12, 0, 1, 2, False, filename)
 
-# Storing happens when Get_Player_Information is called
-def Get_and_Store_All_Players_Names_and_Ids(filename):
-    Players = {}
-    PlayerType = ['current','historical']
-    for playertype in PlayerType:
-        for Last_Name_Beginning in list(string.ascii_uppercase):
-            print('Getting %s players whose last name starts with %s' % (playertype,
-                                                             Last_Name_Beginning))
+        page_number += 1
+
+
+# Storing happens when get_player_information is called
+def get_and_store_all_players_names_and_ids(filename):
+    players = {}
+    player_types = ['current', 'historical']
+    for player_type in player_types:
+        for last_name_beginning in list(string.ascii_uppercase):
+            print('Getting %s players whose last name starts with %s' % (player_type, last_name_beginning))
             
-            url_parameters = {'category':'lastName','filter':Last_Name_Beginning,
-                          'playerType':playertype}
-            initial_url = 'http://www.nfl.com/players/search'
-            soup = Get_HTML_Document(initial_url,url_parameters)
-    
-            Max_Page = Obtain_Number_of_Pages(soup,initial_url)
-    
-            Obtain_Players_And_Status(initial_url,url_parameters,Max_Page,Players,
-                                      soup,filename)
-    return Players
- 
+            url_parameters = {'category': 'lastName',
+                              'filter': last_name_beginning,
+                              'playerType': player_type}
 
+            initial_url = 'http://www.nfl.com/players/search'
+            soup = Get_HTML_Document(initial_url, url_parameters)
+
+            obtain_players_and_status(initial_url, url_parameters, players, soup, filename)
+
+    return players


### PR DESCRIPTION
Fix a bug where a large amount of player IDs were not gathered. 

From the initial search page, the function get_and_store_all_players_names_and_ids found the max number of pages for this search, and then iterated through all pages between 1 and the max number of pages. Using this approach, the max number of pages is limited to at most 10, even if there are many more.  Testing this manually yourself at http://www.nfl.com/players/search however shows that for categories with a large amount of players (e.g. historical players with surnames starting with 'M') once the 10th page is reached the max page number has increased to 14. Due to this, a large amount of historical players are missed by this script - a run of this script without changes gathered 16640 players and with the proposed fix 29814 players are gathered.

The fix proposed for this is to update the estimate of the maximum number of pages on each page that is scraped with the new visible maximum value. Also included is a number of changes to the formatting in order to follow PEP-8 (https://www.python.org/dev/peps/pep-0008/)